### PR TITLE
Refine launcher support surfaces and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "srclauncher",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "srclauncher",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "srclauncher",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "srclauncher"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "dll-syringe",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srclauncher"
-version = "0.1.5"
+version = "0.1.6"
 description = "SRCLauncher"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -57,7 +57,7 @@ pub struct RepoArgs {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DiagnosticsArgs {
+pub struct RepoDiagnosticsArgs {
     pub repo: Option<String>,
 }
 
@@ -121,8 +121,18 @@ pub fn append_launcher_log(app: AppHandle, message: String) -> Result<(), String
 }
 
 #[tauri::command]
-pub fn open_logs(app: AppHandle) -> Result<String, String> {
-    support::open_logs(&app)
+pub fn open_launcher_logs(app: AppHandle) -> Result<String, String> {
+    support::open_launcher_logs(&app)
+}
+
+#[tauri::command]
+pub fn open_client_crashlogs_folder() -> Result<String, String> {
+    support::open_client_crashlogs_folder()
+}
+
+#[tauri::command]
+pub fn open_client_config_folder() -> Result<String, String> {
+    support::open_client_config_folder()
 }
 
 #[tauri::command]
@@ -142,9 +152,17 @@ pub fn clear_cache(app: AppHandle) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn collect_diagnostics(app: AppHandle, args: DiagnosticsArgs) -> Result<String, String> {
+pub fn collect_launcher_diagnostics(
+    app: AppHandle,
+    args: RepoDiagnosticsArgs,
+) -> Result<String, String> {
     let repo = args.repo.as_deref().map(normalize_repo).transpose()?;
-    support::collect_diagnostics(&app, repo.as_deref())
+    support::collect_launcher_diagnostics(&app, repo.as_deref())
+}
+
+#[tauri::command]
+pub fn collect_client_diagnostics() -> Result<String, String> {
+    support::collect_client_diagnostics()
 }
 
 #[tauri::command]
@@ -213,9 +231,8 @@ pub async fn install_launcher_update(app: AppHandle) -> Result<(), String> {
     update
         .download_and_install(
             |chunk_length, content_length| {
-                let current =
-                    on_chunk_downloaded.fetch_add(chunk_length as u64, Ordering::Relaxed)
-                        + chunk_length as u64;
+                let current = on_chunk_downloaded.fetch_add(chunk_length as u64, Ordering::Relaxed)
+                    + chunk_length as u64;
                 emit_transfer_progress(
                     &app,
                     LAUNCHER_UPDATE_PROGRESS_EVENT,
@@ -281,12 +298,13 @@ pub async fn download_injection_library(
         .find(|asset| asset.name == library_name)
         .map(|asset| asset.browser_download_url.clone())
         .ok_or_else(|| {
-            format!(
-                "release_asset_missing: repo={repo} release=latest asset={library_name}"
-            )
+            format!("release_asset_missing: repo={repo} release=latest asset={library_name}")
         })?;
 
-    let cache_dir = support::repo_cache_dir(&app, &repo)?;
+    let cache_dir =
+        support::repo_cache_dir(&app, &repo)?.join(support::sanitize_path_part(&release.tag_name));
+    std::fs::create_dir_all(&cache_dir)
+        .map_err(|e| format!("io_error: cannot create release cache dir: {e}"))?;
     let cached_artifact_path = cache_dir.join(library_name);
     if cached_artifact_path.exists() {
         return Ok(cached_artifact_path.to_string_lossy().into_owned());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,11 +15,8 @@ pub fn run() {
         .setup(|app| {
             if let Some(pubkey) = launcher_updater_pubkey() {
                 #[cfg(desktop)]
-                app.handle().plugin(
-                    tauri_plugin_updater::Builder::new()
-                        .pubkey(pubkey)
-                        .build(),
-                )?;
+                app.handle()
+                    .plugin(tauri_plugin_updater::Builder::new().pubkey(pubkey).build())?;
             }
 
             Ok(())
@@ -29,11 +26,14 @@ pub fn run() {
             commands::save_settings,
             commands::detect_subrosa,
             commands::append_launcher_log,
-            commands::open_logs,
+            commands::open_launcher_logs,
+            commands::open_client_crashlogs_folder,
+            commands::open_client_config_folder,
             commands::open_cache_folder,
             commands::force_redownload,
             commands::clear_cache,
-            commands::collect_diagnostics,
+            commands::collect_launcher_diagnostics,
+            commands::collect_client_diagnostics,
             commands::copy_text_to_clipboard,
             commands::get_launcher_update_state,
             commands::install_launcher_update,

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -209,18 +209,18 @@ pub fn collect_client_diagnostics() -> Result<String, String> {
                     path.display()
                 )
             })?;
-            let crashlog_tail = read_log_tail(&path, 20)?;
+            let crashlog_contents = read_text_file(&path)?;
 
             diagnostics.push(format!("client.latestCrashlog={}", path.to_string_lossy()));
             diagnostics.push(format!("client.latestCrashlog.bytes={}", metadata.len()));
             diagnostics.push(format!("client.latestCrashlog.modified={modified}"));
-            diagnostics.push("client.latestCrashlog.tail.begin".to_string());
-            if crashlog_tail.is_empty() {
+            diagnostics.push("client.latestCrashlog.begin".to_string());
+            if crashlog_contents.is_empty() {
                 diagnostics.push("(empty)".to_string());
             } else {
-                diagnostics.extend(crashlog_tail);
+                diagnostics.extend(crashlog_contents.lines().map(ToString::to_string));
             }
-            diagnostics.push("client.latestCrashlog.tail.end".to_string());
+            diagnostics.push("client.latestCrashlog.end".to_string());
         }
         None => {
             diagnostics.push("client.latestCrashlog=missing".to_string());
@@ -416,6 +416,14 @@ fn read_log_tail(path: &Path, max_lines: usize) -> Result<Vec<String>, String> {
         lines.drain(..lines.len() - max_lines);
     }
     Ok(lines)
+}
+
+fn read_text_file(path: &Path) -> Result<String, String> {
+    if !path.exists() {
+        return Ok(String::new());
+    }
+
+    fs::read_to_string(path).map_err(|e| format!("io_error: cannot read log file: {e}"))
 }
 
 fn latest_file_in_dir(path: &Path) -> Result<Option<PathBuf>, String> {

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -1,16 +1,21 @@
+use chrono::{DateTime, Utc};
 use std::{
-    fs,
+    env, fs,
     io::Write,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     time::SystemTime,
 };
-use chrono::{DateTime, Utc};
 use tauri::{AppHandle, Manager};
 
 use crate::{settings, steam};
 
 const LAUNCHER_LOG_FILE: &str = "launcher.log";
+const CLIENT_CONFIG_DIR_NAME: &str = "Sub Rosa Custom";
+const CLIENT_CRASHLOG_DIR_NAME: &str = "crashlogs";
+const CLIENT_LOCAL_RUNTIME_ROOT_NAME: &str = "subrosacustom";
+const CLIENT_SYNC_CACHE_ROOT_NAME: &str = "sync";
+const CLIENT_TEXTURE_EXPORTS_DIR_NAME: &str = "texture_exports";
 
 pub fn repo_cache_dir(app: &AppHandle, repo: &str) -> Result<PathBuf, String> {
     let cache_dir = cache_root_dir(app)?.join(sanitize_path_part(repo));
@@ -19,7 +24,7 @@ pub fn repo_cache_dir(app: &AppHandle, repo: &str) -> Result<PathBuf, String> {
     Ok(cache_dir)
 }
 
-pub fn open_logs(app: &AppHandle) -> Result<String, String> {
+pub fn open_launcher_logs(app: &AppHandle) -> Result<String, String> {
     let log_dir = ensure_log_dir(app)?;
     let log_file = log_dir.join(LAUNCHER_LOG_FILE);
     if !log_file.exists() {
@@ -27,6 +32,18 @@ pub fn open_logs(app: &AppHandle) -> Result<String, String> {
     }
     open_path_in_file_manager(&log_dir)?;
     Ok(log_dir.to_string_lossy().into_owned())
+}
+
+pub fn open_client_crashlogs_folder() -> Result<String, String> {
+    let crashlog_dir = ensure_client_crashlog_dir()?;
+    open_path_in_file_manager(&crashlog_dir)?;
+    Ok(crashlog_dir.to_string_lossy().into_owned())
+}
+
+pub fn open_client_config_folder() -> Result<String, String> {
+    let client_dir = ensure_client_config_dir()?;
+    open_path_in_file_manager(&client_dir)?;
+    Ok(client_dir.to_string_lossy().into_owned())
 }
 
 pub fn open_cache_folder(app: &AppHandle) -> Result<String, String> {
@@ -66,7 +83,7 @@ pub fn append_launcher_log(app: &AppHandle, message: &str) -> Result<(), String>
         .map_err(|e| format!("io_error: cannot write log file: {e}"))
 }
 
-pub fn collect_diagnostics(app: &AppHandle, repo: Option<&str>) -> Result<String, String> {
+pub fn collect_launcher_diagnostics(app: &AppHandle, repo: Option<&str>) -> Result<String, String> {
     let detection = steam::detect_subrosa();
     let settings_summary = match settings::load_settings(app) {
         Ok(settings) => format!(
@@ -125,6 +142,105 @@ pub fn collect_diagnostics(app: &AppHandle, repo: Option<&str>) -> Result<String
     Ok(diagnostics.join("\n"))
 }
 
+pub fn collect_client_diagnostics() -> Result<String, String> {
+    let config_root = client_config_dir()?;
+    let crashlog_root = config_root.join(CLIENT_CRASHLOG_DIR_NAME);
+    let local_runtime_root = config_root.join(CLIENT_LOCAL_RUNTIME_ROOT_NAME);
+    let local_scripts_root = local_runtime_root.join("scripts");
+    let sync_cache_root = config_root.join(CLIENT_SYNC_CACHE_ROOT_NAME);
+    let texture_exports_root = config_root.join(CLIENT_TEXTURE_EXPORTS_DIR_NAME);
+    let latest_crashlog = latest_file_in_dir(&crashlog_root)?;
+    let has_latest_crashlog = latest_crashlog.is_some();
+
+    let mut diagnostics = vec![
+        format!("timestamp={}", timestamp_rfc3339_now()),
+        format!("platform.os={}", std::env::consts::OS),
+        format!("platform.arch={}", std::env::consts::ARCH),
+        format!("client.configRoot={}", config_root.to_string_lossy()),
+        format!("client.configRoot.exists={}", config_root.exists()),
+        format!("client.crashlogRoot={}", crashlog_root.to_string_lossy()),
+        format!(
+            "client.crashlogRoot.summary={}",
+            summarize_dir(&crashlog_root)?
+        ),
+        "client.syncMode=in-memory scripts".to_string(),
+        format!(
+            "client.localRuntimeRoot={}",
+            local_runtime_root.to_string_lossy()
+        ),
+        format!(
+            "client.localRuntimeRoot.summary={}",
+            summarize_dir(&local_runtime_root)?
+        ),
+        format!(
+            "client.localScriptsRoot={}",
+            local_scripts_root.to_string_lossy()
+        ),
+        format!(
+            "client.localScriptsRoot.summary={}",
+            summarize_dir(&local_scripts_root)?
+        ),
+        format!("client.syncCacheRoot={}", sync_cache_root.to_string_lossy()),
+        format!(
+            "client.syncCacheRoot.summary={}",
+            summarize_dir(&sync_cache_root)?
+        ),
+        format!(
+            "client.textureExportsRoot={}",
+            texture_exports_root.to_string_lossy()
+        ),
+        format!(
+            "client.textureExportsRoot.summary={}",
+            summarize_dir(&texture_exports_root)?
+        ),
+    ];
+
+    match latest_crashlog {
+        Some(path) => {
+            let metadata = fs::metadata(&path).map_err(|e| {
+                format!(
+                    "io_error: cannot read crashlog metadata {}: {e}",
+                    path.display()
+                )
+            })?;
+            let modified = metadata.modified().map(timestamp_rfc3339).map_err(|e| {
+                format!(
+                    "io_error: cannot read crashlog modified time {}: {e}",
+                    path.display()
+                )
+            })?;
+            let crashlog_tail = read_log_tail(&path, 20)?;
+
+            diagnostics.push(format!("client.latestCrashlog={}", path.to_string_lossy()));
+            diagnostics.push(format!("client.latestCrashlog.bytes={}", metadata.len()));
+            diagnostics.push(format!("client.latestCrashlog.modified={modified}"));
+            diagnostics.push("client.latestCrashlog.tail.begin".to_string());
+            if crashlog_tail.is_empty() {
+                diagnostics.push("(empty)".to_string());
+            } else {
+                diagnostics.extend(crashlog_tail);
+            }
+            diagnostics.push("client.latestCrashlog.tail.end".to_string());
+        }
+        None => {
+            diagnostics.push("client.latestCrashlog=missing".to_string());
+        }
+    }
+
+    let status = if has_latest_crashlog {
+        "client crash evidence found"
+    } else if sync_cache_root.exists() {
+        "client sync cache present"
+    } else if local_runtime_root.exists() {
+        "client local runtime present"
+    } else {
+        "no client evidence found"
+    };
+    diagnostics.push(format!("client.status={status}"));
+
+    Ok(diagnostics.join("\n"))
+}
+
 pub fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
@@ -159,6 +275,53 @@ pub fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
 
 fn launcher_log_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(ensure_log_dir(app)?.join(LAUNCHER_LOG_FILE))
+}
+
+fn client_config_dir() -> Result<PathBuf, String> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(path) = env::var_os("APPDATA") {
+            return Ok(PathBuf::from(path).join(CLIENT_CONFIG_DIR_NAME));
+        }
+
+        let home = env::var_os("USERPROFILE")
+            .ok_or_else(|| "path_error: cannot resolve USERPROFILE".to_string())?;
+        return Ok(PathBuf::from(home)
+            .join("AppData")
+            .join("Roaming")
+            .join(CLIENT_CONFIG_DIR_NAME));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Some(path) = env::var_os("XDG_CONFIG_HOME") {
+            let config_home = PathBuf::from(path);
+            if !config_home.is_absolute() {
+                return Err("path_error: XDG_CONFIG_HOME must be absolute".to_string());
+            }
+            return Ok(config_home.join(CLIENT_CONFIG_DIR_NAME));
+        }
+
+        let home =
+            env::var_os("HOME").ok_or_else(|| "path_error: cannot resolve HOME".to_string())?;
+        Ok(PathBuf::from(home)
+            .join(".config")
+            .join(CLIENT_CONFIG_DIR_NAME))
+    }
+}
+
+fn ensure_client_config_dir() -> Result<PathBuf, String> {
+    let client_dir = client_config_dir()?;
+    fs::create_dir_all(&client_dir)
+        .map_err(|e| format!("io_error: cannot create client config dir: {e}"))?;
+    Ok(client_dir)
+}
+
+fn ensure_client_crashlog_dir() -> Result<PathBuf, String> {
+    let crashlog_dir = ensure_client_config_dir()?.join(CLIENT_CRASHLOG_DIR_NAME);
+    fs::create_dir_all(&crashlog_dir)
+        .map_err(|e| format!("io_error: cannot create client crashlog dir: {e}"))?;
+    Ok(crashlog_dir)
 }
 
 fn ensure_log_dir(app: &AppHandle) -> Result<PathBuf, String> {
@@ -255,11 +418,49 @@ fn read_log_tail(path: &Path, max_lines: usize) -> Result<Vec<String>, String> {
     Ok(lines)
 }
 
+fn latest_file_in_dir(path: &Path) -> Result<Option<PathBuf>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let mut latest: Option<(SystemTime, PathBuf)> = None;
+    for entry in fs::read_dir(path)
+        .map_err(|e| format!("io_error: cannot read directory {}: {e}", path.display()))?
+    {
+        let entry = entry.map_err(|e| format!("io_error: cannot read directory entry: {e}"))?;
+        let entry_path = entry.path();
+        let metadata = entry.metadata().map_err(|e| {
+            format!(
+                "io_error: cannot read metadata {}: {e}",
+                entry_path.display()
+            )
+        })?;
+
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let modified = metadata.modified().map_err(|e| {
+            format!(
+                "io_error: cannot read modified time {}: {e}",
+                entry_path.display()
+            )
+        })?;
+
+        match &latest {
+            Some((current, _)) if modified <= *current => {}
+            _ => latest = Some((modified, entry_path)),
+        }
+    }
+
+    Ok(latest.map(|(_, path)| path))
+}
+
 fn option_line(value: &Option<String>) -> &str {
     value.as_deref().unwrap_or("missing")
 }
 
-fn sanitize_path_part(value: &str) -> String {
+pub fn sanitize_path_part(value: &str) -> String {
     value
         .chars()
         .map(|ch| {
@@ -325,6 +526,10 @@ fn run_copy_command(program: &str, args: &[&str], text: &str) -> Result<(), Stri
 }
 
 fn timestamp_rfc3339_now() -> String {
-    let timestamp: DateTime<Utc> = SystemTime::now().into();
+    timestamp_rfc3339(SystemTime::now())
+}
+
+fn timestamp_rfc3339(time: SystemTime) -> String {
+    let timestamp: DateTime<Utc> = time.into();
     timestamp.to_rfc3339()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "srclauncher",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.src.launcher",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -192,6 +192,18 @@ button {
   inset: 0;
   z-index: 30;
   background: var(--bg);
+  padding: 14px;
+}
+
+.settings-shell {
+  width: min(980px, calc(100vw - 28px));
+  height: min(760px, calc(100vh - 28px));
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  background: rgba(8, 8, 8, 0.96);
 }
 
 .update-modal-backdrop {
@@ -245,31 +257,37 @@ button {
 }
 
 .settings-top {
-  position: absolute;
-  top: 14px;
-  left: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 14px;
 }
 
 .settings-body {
-  width: min(980px, calc(100vw - 48px));
-  margin: 50px auto 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  align-items: flex-start;
+  gap: 14px;
+  flex: 1 1 auto;
+  overflow: hidden;
+  padding: 18px 20px 18px;
 }
 
 .settings-actions {
-  position: absolute;
-  right: 24px;
-  bottom: 24px;
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px 18px;
 }
 
 .settings-section {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+}
+
+.helper-title {
+  font-size: 0.9rem;
+  text-transform: lowercase;
 }
 
 .settings-row {
@@ -296,9 +314,10 @@ button {
 }
 
 .toggle-btn {
-  min-width: min(700px, calc(100vw - 200px));
+  width: auto;
+  min-width: 0;
   min-height: 40px;
-  padding: 0px 3px;
+  padding: 0px 10px 0px 3px;
   border: 4px solid var(--hover);
   background-color: var(--bg);
   background: transparent;
@@ -355,4 +374,39 @@ button {
   width: auto;
   min-width: 170px;
   padding: 0 16px;
+}
+
+.settings-back-btn,
+.settings-save-btn {
+  width: auto;
+  min-width: 180px;
+  padding: 0 16px;
+}
+
+@media (max-width: 720px) {
+  .settings-page {
+    padding: 0;
+  }
+
+  .settings-shell {
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+
+  .settings-top,
+  .settings-body,
+  .settings-actions {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .settings-row input {
+    width: 100%;
+  }
+
+  .toggle-btn {
+    width: auto;
+    min-width: 0;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import SettingsPanel from './components/SettingsPanel';
 import {
   appendLauncherLog,
   clearCache,
-  collectDiagnostics,
+  collectClientDiagnostics,
+  collectLauncherDiagnostics,
   copyTextToClipboard,
   detectSubrosa,
   downloadInjectionLibrary,
@@ -18,7 +19,9 @@ import {
   launchGame,
   loadSettings,
   openCacheFolder,
-  openLogs,
+  openClientConfigFolder,
+  openClientCrashlogsFolder,
+  openLauncherLogs,
   saveSettings,
 } from './api/launcher';
 import type {
@@ -295,10 +298,30 @@ function App() {
     }
   };
 
-  const handleOpenLogs = () =>
-    void runSupportAction('openLogs', async () => {
-      const path = await openLogs();
-      appendLog(`Opened logs: ${path}`);
+  const copySupportText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      await copyTextToClipboard(text);
+    }
+  };
+
+  const handleOpenLauncherLogs = () =>
+    void runSupportAction('openLauncherLogs', async () => {
+      const path = await openLauncherLogs();
+      appendLog(`Opened launcher logs: ${path}`);
+    });
+
+  const handleOpenClientCrashlogsFolder = () =>
+    void runSupportAction('openClientCrashlogsFolder', async () => {
+      const path = await openClientCrashlogsFolder();
+      appendLog(`Opened client crashlogs: ${path}`);
+    });
+
+  const handleOpenClientConfigFolder = () =>
+    void runSupportAction('openClientConfigFolder', async () => {
+      const path = await openClientConfigFolder();
+      appendLog(`Opened client config folder: ${path}`);
     });
 
   const handleOpenCacheFolder = () =>
@@ -319,17 +342,18 @@ function App() {
       appendLog(`Cleared launcher cache: ${path}`);
     });
 
-  const handleCopyDiagnostics = () =>
-    void runSupportAction('copyDiagnostics', async () => {
-      const diagnostics = await collectDiagnostics(configuredLibraryRequest.repo);
+  const handleCopyLauncherDiagnostics = () =>
+    void runSupportAction('copyLauncherDiagnostics', async () => {
+      const diagnostics = await collectLauncherDiagnostics(configuredLibraryRequest.repo);
+      await copySupportText(diagnostics);
+      appendLog('Launcher diagnostics copied to clipboard.');
+    });
 
-      try {
-        await navigator.clipboard.writeText(diagnostics);
-      } catch {
-        await copyTextToClipboard(diagnostics);
-      }
-
-      appendLog('Diagnostics copied to clipboard.');
+  const handleCopyClientDiagnostics = () =>
+    void runSupportAction('copyClientDiagnostics', async () => {
+      const diagnostics = await collectClientDiagnostics();
+      await copySupportText(diagnostics);
+      appendLog('Client diagnostics copied to clipboard.');
     });
 
   const handleInstallLauncherUpdate = async () => {
@@ -399,11 +423,14 @@ function App() {
         executableCandidates={detection?.executableCandidates ?? []}
         onSave={handleSettingsSave}
         onClose={() => setIsSettingsOpen(false)}
-        onOpenLogs={handleOpenLogs}
+        onOpenLauncherLogs={handleOpenLauncherLogs}
+        onOpenClientCrashlogsFolder={handleOpenClientCrashlogsFolder}
+        onOpenClientConfigFolder={handleOpenClientConfigFolder}
         onOpenCacheFolder={handleOpenCacheFolder}
         onForceRedownload={handleForceRedownload}
         onClearCache={handleClearCache}
-        onCopyDiagnostics={handleCopyDiagnostics}
+        onCopyLauncherDiagnostics={handleCopyLauncherDiagnostics}
+        onCopyClientDiagnostics={handleCopyClientDiagnostics}
       />
 
       {showLauncherUpdatePrompt ? (

--- a/src/api/launcher.ts
+++ b/src/api/launcher.ts
@@ -23,8 +23,16 @@ export function appendLauncherLog(message: string) {
   return invoke<void>('append_launcher_log', { message });
 }
 
-export function openLogs() {
-  return invoke<string>('open_logs');
+export function openLauncherLogs() {
+  return invoke<string>('open_launcher_logs');
+}
+
+export function openClientCrashlogsFolder() {
+  return invoke<string>('open_client_crashlogs_folder');
+}
+
+export function openClientConfigFolder() {
+  return invoke<string>('open_client_config_folder');
 }
 
 export function openCacheFolder() {
@@ -39,8 +47,12 @@ export function clearCache() {
   return invoke<string>('clear_cache');
 }
 
-export function collectDiagnostics(repo?: string) {
-  return invoke<string>('collect_diagnostics', { args: { repo } });
+export function collectLauncherDiagnostics(repo?: string) {
+  return invoke<string>('collect_launcher_diagnostics', { args: { repo } });
+}
+
+export function collectClientDiagnostics() {
+  return invoke<string>('collect_client_diagnostics');
 }
 
 export function copyTextToClipboard(text: string) {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { LauncherSettings } from '../types/launcher';
 
+type SettingsView = 'settings' | 'launcherSupport' | 'clientSupport';
+
 interface SettingsPanelProps {
   open: boolean;
   saving: boolean;
@@ -9,11 +11,14 @@ interface SettingsPanelProps {
   executableCandidates: string[];
   onSave: (next: LauncherSettings) => Promise<void>;
   onClose: () => void;
-  onOpenLogs: () => void;
+  onOpenLauncherLogs: () => void;
+  onOpenClientCrashlogsFolder: () => void;
+  onOpenClientConfigFolder: () => void;
   onOpenCacheFolder: () => void;
   onForceRedownload: () => void;
   onClearCache: () => void;
-  onCopyDiagnostics: () => void;
+  onCopyLauncherDiagnostics: () => void;
+  onCopyClientDiagnostics: () => void;
 }
 
 function SettingsPanel({
@@ -24,126 +29,218 @@ function SettingsPanel({
   executableCandidates,
   onSave,
   onClose,
-  onOpenLogs,
+  onOpenLauncherLogs,
+  onOpenClientCrashlogsFolder,
+  onOpenClientConfigFolder,
   onOpenCacheFolder,
   onForceRedownload,
   onClearCache,
-  onCopyDiagnostics,
+  onCopyLauncherDiagnostics,
+  onCopyClientDiagnostics,
 }: SettingsPanelProps) {
   const [executableName, setExecutableName] = useState(settings.executableName);
   const [closeOnLaunch, setCloseOnLaunch] = useState(settings.closeOnLaunch);
+  const [view, setView] = useState<SettingsView>('settings');
 
   useEffect(() => {
     if (!open) return;
     setExecutableName(settings.executableName);
     setCloseOnLaunch(settings.closeOnLaunch);
+    setView('settings');
   }, [open, settings.executableName, settings.closeOnLaunch]);
 
   if (!open) return null;
 
+  const handleBack = () => {
+    if (view !== 'settings') {
+      setView('settings');
+      return;
+    }
+    onClose();
+  };
+
+  const handleSave = () =>
+    onSave({
+      executableName: executableName.trim() || settings.executableName,
+      closeOnLaunch,
+    });
+
   return (
     <div className="settings-page">
-      <div className="settings-top">
-        <button className="action-btn" style={{ height: '30px' }} onClick={onClose}>
-          <span className="btn-label">Back</span>
-        </button>
-      </div>
-      <div className="settings-body">
-        <section className="settings-section">
-          <div className="settings-row">
-            <input
-              id="exeName"
-              value={executableName}
-              onChange={(e) => setExecutableName(e.currentTarget.value)}
-              placeholder="subrosa.x64.exe"
-              autoFocus
-            />
-            <label htmlFor="exeName">Executable name</label>
-          </div>
-          <div className="hint">Suggested: {executableCandidates.join(', ')}</div>
-          <div className="settings-row">
-            <button
-              type="button"
-              className={`toggle-btn ${closeOnLaunch ? 'is-on' : ''}`}
-              onClick={() => setCloseOnLaunch((v) => !v)}
-            >
-              <span className="toggle-box">
-                <span className="toggle-fill" />
-              </span>
-              <span>Close after success</span>
-            </button>
-          </div>
-        </section>
+      <div className="settings-shell">
+        <div className="settings-top">
+          <button className="action-btn settings-back-btn" onClick={handleBack}>
+            <span className="btn-label">{view !== 'settings' ? 'Back to settings' : 'Back'}</span>
+          </button>
+        </div>
 
-        <section className="settings-section">
-          <div className="support-grid">
-            <button
-              type="button"
-              className="action-btn support-btn"
-              onClick={onOpenLogs}
-              disabled={activeSupportAction !== null}
-            >
-              <span className="btn-label">
-                {activeSupportAction === 'openLogs' ? 'Working...' : 'Open logs'}
-              </span>
+        <div className="settings-body">
+          {view === 'settings' ? (
+            <>
+              <section className="settings-section">
+                <div className="settings-row">
+                  <input
+                    id="exeName"
+                    value={executableName}
+                    onChange={(e) => setExecutableName(e.currentTarget.value)}
+                    placeholder="subrosa.x64.exe"
+                    autoFocus
+                  />
+                  <label htmlFor="exeName">Executable name</label>
+                </div>
+                <div className="hint">Suggested: {executableCandidates.join(', ')}</div>
+                <div className="settings-row">
+                  <button
+                    type="button"
+                    className={`toggle-btn ${closeOnLaunch ? 'is-on' : ''}`}
+                    onClick={() => setCloseOnLaunch((v) => !v)}
+                  >
+                    <span className="toggle-box">
+                      <span className="toggle-fill" />
+                    </span>
+                    <span>Close after success</span>
+                  </button>
+                </div>
+              </section>
+
+              <section className="settings-section">
+                <div className="support-grid">
+                  <button
+                    type="button"
+                    className="action-btn support-btn"
+                    onClick={() => setView('launcherSupport')}
+                  >
+                    <span className="btn-label">Open launcher helpers</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="action-btn support-btn"
+                    onClick={() => setView('clientSupport')}
+                  >
+                    <span className="btn-label">Open client helpers</span>
+                  </button>
+                </div>
+              </section>
+            </>
+          ) : (
+            <section className="settings-section">
+              <p className="helper-title">
+                {view === 'launcherSupport' ? 'launcher helpers' : 'client crashlogs'}
+              </p>
+              {view === 'launcherSupport' ? (
+                <>
+                  <div className="support-grid">
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onOpenLauncherLogs}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'openLauncherLogs' ? 'Working...' : 'Open logs'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onOpenCacheFolder}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'openCacheFolder'
+                          ? 'Working...'
+                          : 'Open cache folder'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onForceRedownload}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'forceRedownload'
+                          ? 'Working...'
+                          : 'Force redownload'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onClearCache}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'clearCache' ? 'Working...' : 'Clear cache'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onCopyLauncherDiagnostics}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'copyLauncherDiagnostics'
+                          ? 'Working...'
+                          : 'Copy diagnostics'}
+                      </span>
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="support-grid">
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onOpenClientCrashlogsFolder}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'openClientCrashlogsFolder'
+                          ? 'Working...'
+                          : 'Open crashlogs'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onOpenClientConfigFolder}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'openClientConfigFolder'
+                          ? 'Working...'
+                          : 'Open config folder'}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="action-btn support-btn"
+                      onClick={onCopyClientDiagnostics}
+                      disabled={activeSupportAction !== null}
+                    >
+                      <span className="btn-label">
+                        {activeSupportAction === 'copyClientDiagnostics'
+                          ? 'Working...'
+                          : 'Copy diagnostics'}
+                      </span>
+                    </button>
+                  </div>
+                </>
+              )}
+            </section>
+          )}
+        </div>
+
+        <div className="settings-actions">
+          {view === 'settings' ? (
+            <button className="action-btn settings-save-btn" onClick={handleSave} disabled={saving}>
+              <span className="btn-label">{saving ? 'Saving...' : 'Save'}</span>
             </button>
-            <button
-              type="button"
-              className="action-btn support-btn"
-              onClick={onOpenCacheFolder}
-              disabled={activeSupportAction !== null}
-            >
-              <span className="btn-label">
-                {activeSupportAction === 'openCacheFolder' ? 'Working...' : 'Open cache folder'}
-              </span>
-            </button>
-            <button
-              type="button"
-              className="action-btn support-btn"
-              onClick={onForceRedownload}
-              disabled={activeSupportAction !== null}
-            >
-              <span className="btn-label">
-                {activeSupportAction === 'forceRedownload' ? 'Working...' : 'Force redownload'}
-              </span>
-            </button>
-            <button
-              type="button"
-              className="action-btn support-btn"
-              onClick={onClearCache}
-              disabled={activeSupportAction !== null}
-            >
-              <span className="btn-label">
-                {activeSupportAction === 'clearCache' ? 'Working...' : 'Clear cache'}
-              </span>
-            </button>
-            <button
-              type="button"
-              className="action-btn support-btn"
-              onClick={onCopyDiagnostics}
-              disabled={activeSupportAction !== null}
-            >
-              <span className="btn-label">
-                {activeSupportAction === 'copyDiagnostics' ? 'Working...' : 'Copy diagnostics'}
-              </span>
-            </button>
-          </div>
-        </section>
-      </div>
-      <div className="settings-actions">
-        <button
-          className="action-btn"
-          style={{ height: '40px' }}
-          onClick={() =>
-            onSave({
-              executableName: executableName.trim() || settings.executableName,
-              closeOnLaunch,
-            })
-          }
-          disabled={saving}
-        >
-          <span className="btn-label">{saving ? 'Saving...' : 'Save'}</span>
-        </button>
+          ) : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refine launcher and client support surfaces
- align client crashlog diagnostics with full crashlog output
- bump launcher version from 0.1.5 to 0.1.6

## Validation
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml